### PR TITLE
Add error annotation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ Without specifying a language, the editor will default to `python`. You can also
 response_dict = code_editor(your_code_string, lang="javascript")
 ```
 By default, each code editor is styled like streamlit's code component. We will go over how to customize the styling in a later section.
+
+### Displaying Error Annotations
+
+The editor accepts an optional `annotations` argument. Pass a list of
+Ace style annotation dictionaries to highlight errors returned by your
+backend:
+
+```python
+annotations = [{"row": 2, "column": 4, "text": "syntax error", "type": "error"}]
+response_dict = code_editor(query, lang="sql", annotations=annotations)
+```
+
 ## Docs [![Component Guide](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://code-editor-documentation.streamlit.app/)
 ![guide](./examples/resources/guide_screenshot.png)
 

--- a/code_editor/__init__.py
+++ b/code_editor/__init__.py
@@ -46,7 +46,7 @@ else:
 # `declare_component` and call it done. The wrapper allows us to customize
 # our component's API: we can pre-process its input args, post-process its
 # output value, and add a docstring for users.
-def code_editor(code, lang='python', theme="default", shortcuts="vscode", height=30, focus=False, allow_reset=False, replace_completer=False, response_mode="default", ghost_text="", snippets=["", ""], completions=[], keybindings={}, buttons=[], menu={}, info={}, options={}, props={}, editor_props={}, component_props={}, key=None):
+def code_editor(code, lang='python', theme="default", shortcuts="vscode", height=30, focus=False, allow_reset=False, replace_completer=False, response_mode="default", ghost_text="", snippets=["", ""], completions=[], keybindings={}, buttons=[], menu={}, info={}, annotations=None, options={}, props={}, editor_props={}, component_props={}, key=None):
     """Create a new instance of "code_editor".
 
     Parameters
@@ -70,7 +70,7 @@ def code_editor(code, lang='python', theme="default", shortcuts="vscode", height
     #
     # "default" is a special argument that specifies the initial return
     # value of the component before the user has interacted with it.
-    component_value = _component_func(code=code, lang=lang, theme=theme, key=key, height=height, focus=focus, shortcuts=shortcuts, snippets=snippets, completions=completions, keybindings=keybindings, buttons=buttons, options=options, props=props, editor_props=editor_props, component_props=component_props, menu=menu, info=info, allow_reset=allow_reset, replace_completer=replace_completer, response_mode=response_mode, ghost_text=ghost_text, default={"id": "", "type": "", "lang": "", "text": "", "selected": "", "cursor": ""})
+    component_value = _component_func(code=code, lang=lang, theme=theme, key=key, height=height, focus=focus, shortcuts=shortcuts, snippets=snippets, completions=completions, keybindings=keybindings, buttons=buttons, menu=menu, info=info, annotations=annotations or [], options=options, props=props, editor_props=editor_props, component_props=component_props, allow_reset=allow_reset, replace_completer=replace_completer, response_mode=response_mode, ghost_text=ghost_text, default={"id": "", "type": "", "lang": "", "text": "", "selected": "", "cursor": ""})
 
     # We could modify the value returned from the component if we wanted.
     # There's no need to do this in our simple example - but it's an option.

--- a/code_editor/frontend/src/CodeEditor.tsx
+++ b/code_editor/frontend/src/CodeEditor.tsx
@@ -656,8 +656,9 @@ const CodeEditor = ({ args, width, disabled, theme }: CodeEditorProps) => {
          commands={commands.commands} 
          completions={revertedArgs['completions']}
          replaceCompleter={revertedArgs['replace_completer']}
-         keybindingString={keybindings} 
-         props={aceProps} 
+         keybindingString={keybindings}
+         annotations={revertedArgs['annotations']}
+         props={aceProps}
          onChange={onChangeHandler}
          onSelectionChange={onSelectionChangeHandler}
          onBlur={onEditorBlur}  

--- a/code_editor/frontend/src/editor.tsx
+++ b/code_editor/frontend/src/editor.tsx
@@ -34,12 +34,13 @@ export type EditorProps = {
     completions: object[],
     keybindingString: string,
     replaceCompleter: boolean,
+    annotations?: ace.Ace.Annotation[],
     onChange: (value: string, event?: any) => void,
     onSelectionChange: (value: any, event?: any) => void,
     onBlur: (event: any, editor?: any) => void
   }
   
-export const Editor = ({ lang, theme, shortcuts, props, snippetString, commands, completions, ghostText, keybindingString, editorRef, code, replaceCompleter, onChange, onSelectionChange, onBlur }: EditorProps ) => {
+export const Editor = ({ lang, theme, shortcuts, props, snippetString, commands, completions, ghostText, keybindingString, editorRef, code, replaceCompleter, annotations, onChange, onSelectionChange, onBlur }: EditorProps ) => {
     
   let commandsList = useRef<object[]>(commands);
   useEffect(() => {
@@ -130,11 +131,12 @@ export const Editor = ({ lang, theme, shortcuts, props, snippetString, commands,
            mode={lang}
            theme={theme}
            value={code}
-           keyboardHandler={shortcuts}
-           commands={commandsList.current}
-           onChange={onChange}
-           onSelectionChange={onSelectionChange}
-           onBlur={onBlur}
-           {...props}/>
+          keyboardHandler={shortcuts}
+          commands={commandsList.current}
+          annotations={annotations}
+          onChange={onChange}
+          onSelectionChange={onSelectionChange}
+          onBlur={onBlur}
+          {...props}/>
   );
 };


### PR DESCRIPTION
## Summary
- expose `annotations` argument in Python API
- document how to display error annotations in README
- plumb annotations through React code